### PR TITLE
remove unneeded references

### DIFF
--- a/PostgreKeyRotation/PostgreKeyRotation/PostgreKeyRotation.csproj
+++ b/PostgreKeyRotation/PostgreKeyRotation/PostgreKeyRotation.csproj
@@ -6,12 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.7.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Npgsql" Version="4.1.2" />
   </ItemGroup>


### PR DESCRIPTION
The C# solution doesn't seem to reference these packages at all. If they do become needed, they should be replaced with the latest packages referenced here https://docs.microsoft.com/en-us/azure/key-vault/general/client-libraries